### PR TITLE
add sentence to explain looking at a screenshot

### DIFF
--- a/guide/13-managing-arcgis-applications/experience-builder-workflows.ipynb
+++ b/guide/13-managing-arcgis-applications/experience-builder-workflows.ipynb
@@ -9,7 +9,9 @@
     "\n",
     "As of version 2.2.0 of the ArcGIS API for Python, users can now work directly with [Experience Builder](https://www.esri.com/en-us/arcgis/products/arcgis-experience-builder/overview) items, enabling some very helpful content management workflows. In this notebook, we'll give an overview of the class and its properties before diving into some handy usage examples.\n",
     "\n",
-    "## Class Basics"
+    "## Class Basics\n",
+    "\n",
+    "First let's examine a screenshot of the `Web Experience` class help from the API reference:"
    ]
   },
   {
@@ -636,7 +638,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Guide looks great @nparavicini7. Can we just add this sentence to introduce the screenshot. Then we're good to go.

![image](https://github.com/nparavicini7/arcgis-python-api/assets/1399179/fedc2aa8-3647-4f44-a133-6aa0e7ac1e65)
